### PR TITLE
fix: upgrade GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,17 +12,20 @@ concurrency:
   group: pages-${{ github.ref_name }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -45,7 +48,7 @@ jobs:
 
       - name: Checkout gh-pages branch for staging
         if: github.ref_name == 'main'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: .gh-pages


### PR DESCRIPTION
- actions/checkout v4 → v6
- actions/setup-node v4 → v6
- node-version 20 → 22
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for peaceiris/actions-gh-pages